### PR TITLE
More CLI harmony.

### DIFF
--- a/makesurface/scripts/cli.py
+++ b/makesurface/scripts/cli.py
@@ -13,7 +13,7 @@ def cli():
 
 @click.argument('outfile', type=str)
 
-@click.option('--band', '-b', default=None,
+@click.option('--bidx', '-b', default=None,
     help='Input band to vectorize. Can be a number, or a band name [default = 1]')
 
 @click.option('--classes', '-cl', default='10',
@@ -28,7 +28,7 @@ def cli():
 @click.option('--smoothing', '-s', type=int,
     help='Value by which to zoom and smooth the data [default = None]')
 
-@click.option('--nodata', '-nd', default=None,
+@click.option('--nodata', '-n', default=None,
     help='Manually defined nodata value - can be any number or "min" [default = None]')
 
 @click.option('--setnodata', '-set', default=None, type=float,
@@ -36,7 +36,7 @@ def cli():
 
 @click.option('--carto', '-c', is_flag=True)
 
-@click.option('--nibble', '-n', is_flag=True,
+@click.option('--nibble', '-ni', is_flag=True,
     help='Expand mask by 1 pixel')
 
 @click.option('--globewrap', '-g', is_flag=True,
@@ -57,19 +57,19 @@ def vectorize(infile, outfile, classes, classfile, weight, smoothing, nodata, ba
     makesurface.vectorize(infile, outfile, classes, classfile, weight, nodata, smoothing, band, carto, globewrap, axonometrize, nosimple, setnodata, nibble, rapfix)
 
 @click.command()
-@click.option('--bbox', type=str, default=None,
+@click.option('--bounds', nargs=4, type=float, default=None,
     help='Bounding Box ("w s e n") to create lattice in')
-@click.option('--tile', type=str, default=None,
+@click.option('--tile', nargs=3, type=int, default=None,
     help='Tile ("x y z") to create lattice in')
 @click.option('--output', type=str, default=None,
     help='File to write to (.geojson)')
 @click.argument('zoom', type=int)
 
-def triangulate(zoom, output, bbox, tile):
+def triangulate(zoom, output, bounds, tile):
     """
     Creates triangular lattice at specified zoom (where triangle size == tile size)'
     """
-    makesurface.triangulate(zoom, output, bbox, tile)
+    makesurface.triangulate(zoom, output, bounds, tile)
 
 @click.command()
 @click.argument('infile', type=str)

--- a/makesurface/scripts/triangulate_raster.py
+++ b/makesurface/scripts/triangulate_raster.py
@@ -62,11 +62,11 @@ def getCorners(bounds, boolKey):
         corners[coordOrd[boolKey][1]]
     ]
 
-def triangulate(zoom, output, bounds, tile):
+def triangulate(zoom, output, bounds=None, tile=None):
     if bounds:
-        bounds = np.array(bounds.split(' ')).astype(np.float64)
+        bounds = np.array(bounds).astype(np.float64)
     elif tile:
-        tile = np.array(tile.split(' ')).astype(np.uint16)
+        tile = np.array(tile).astype(np.uint16)
         tBounds = mercantile.bounds(tile[0], tile[1], tile[2])
         bounds = np.array([tBounds.west, tBounds.south, tBounds.east , tBounds.north])
     else:

--- a/makesurface/scripts/triangulate_raster.py
+++ b/makesurface/scripts/triangulate_raster.py
@@ -67,7 +67,7 @@ def triangulate(zoom, output, bounds=None, tile=None):
         bounds = np.array(bounds).astype(np.float64)
     elif tile:
         tile = np.array(tile).astype(np.uint16)
-        tBounds = mercantile.bounds(tile[0], tile[1], tile[2])
+        tBounds = mercantile.bounds(*tile)
         bounds = np.array([tBounds.west, tBounds.south, tBounds.east , tBounds.north])
     else:
         sys.exit('Error: A bounds or tile must be specified')


### PR DESCRIPTION
I'm suggesting a couple changes in the interest of harmony between makesurface and rasterio and a more common CLI feel. Let's have our common options be as uniform as we can make them, it makes them easier to use.

## Vectorize

1. Change the --band option to --bidx as in rio-stack etc. I like -b as the short option name and will make sure that's what rio uses.
2. Change the short option name for --nodata to -n as in GDAL programs. This means moving the one for --nibble to -ni, but I feel like --nodata is the more commonly used option across all our scripts.

## Triangulate

1. Change --bbox to --bounds as in rio-merge and make it a 4 float tuple (I've followed up in the function that uses it).
2. Change --tile to a 3 float tuple (ditto).