### PR TITLE
Err handle etc

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ Options:
   --bounds FLOAT...  Bounding Box ("w s e n") to create lattice in
   --tile INTEGER...  Tile ("x y z") to create lattice in
   --output TEXT      File to write to (.geojson)
+  --tableid TEXT     static id for databases
   --help             Show this message and exit.
 ```
 

--- a/README.rst
+++ b/README.rst
@@ -83,6 +83,7 @@ Creates an empty triangular lattice: |image0|
       --bounds FLOAT...  Bounding Box ("w s e n") to create lattice in
       --tile INTEGER...  Tile ("x y z") to create lattice in
       --output TEXT      File to write to (.geojson)
+      --tableid TEXT     static id for databases
       --help             Show this message and exit.
 
 Usage - fillfacets

--- a/makesurface/__init__.py
+++ b/makesurface/__init__.py
@@ -3,8 +3,8 @@ from scripts import vectorize_raster, triangulate_raster, fill_facets
 def vectorize(infile, outfile, classes, classfile, weight, nodata, smoothing, bidx, cartoCSS, axonometrize, nosimple, setNoData, nibbleMask, outvar):
     vectorize_raster.vectorizeRaster(infile, outfile, classes, classfile, weight, nodata, smoothing, bidx, cartoCSS, axonometrize, nosimple, setNoData, nibbleMask, outvar)
 
-def triangulate(zoom, output, bounds, tile):
-    triangulate_raster.triangulate(zoom, output, bounds, tile)
+def triangulate(zoom, output, bounds, tile, tableid):
+    triangulate_raster.triangulate(zoom, output, bounds, tile, tableid)
 
 def fillfacets(infile, sampleRaster, noproject, output, band, zooming, batchprint, outputGeom, color):
     fill_facets.fillFacets(infile, sampleRaster, noproject, output, band, zooming, batchprint, outputGeom, color)

--- a/makesurface/scripts/cli.py
+++ b/makesurface/scripts/cli.py
@@ -48,13 +48,15 @@ def vectorize(infile, outfile, classes, classfile, weight, smoothing, nodata, bi
     help='Tile ("x y z") to create lattice in')
 @click.option('--output', type=str, default=None,
     help='File to write to (.geojson)')
+@click.option('--tableid', type=str, default=None,
+    help='static id for databases')
 @click.argument('zoom', type=int)
 
-def triangulate(zoom, output, bounds, tile):
+def triangulate(zoom, output, bounds, tile, tableid):
     """
     Creates triangular lattice at specified zoom (where triangle size == tile size)'
     """
-    makesurface.triangulate(zoom, output, bounds, tile)
+    makesurface.triangulate(zoom, output, bounds, tile, tableid)
 
 @click.command()
 @click.argument('sampleraster', type=click.Path(exists=True))

--- a/makesurface/scripts/fill_facets.py
+++ b/makesurface/scripts/fill_facets.py
@@ -180,5 +180,8 @@ def fillFacets(geoJSONpath, rasterPath, noProject, output, bands, zooming, batch
                 "features": list(sampleVals)
                 }))
     else:
-        for feat in sampleVals:
-            click.echo(json.dumps(feat))
+        try:
+            for feat in sampleVals:
+                click.echo(json.dumps(feat).rstrip())
+        except IOError as e:
+            pass

--- a/makesurface/scripts/fill_facets.py
+++ b/makesurface/scripts/fill_facets.py
@@ -87,11 +87,11 @@ def getRasterValues(geoJSON, rasArr, UIDs, bounds, outputGeom, bands, color, out
     if outputGeom:
         if outGeoJSON:
             geoJSON = outGeoJSON
-        yield list(
+        return list(
             addGeoJSONprop(feat, bands, rasArr[indices[i][0],indices[i][1]], color) for i, feat in enumerate(geoJSON)
             )
     else: 
-        yield list(
+        return list(
             {
                 'qt': UIDs[i],
                 'attributes': getData(rasArr, inds, bands)

--- a/makesurface/scripts/fill_facets.py
+++ b/makesurface/scripts/fill_facets.py
@@ -71,6 +71,12 @@ def getCenter(feat):
     point = np.array(feat)
     return np.mean(point[0:-1,0]),np.mean(point[0:-1,1])
 
+def getData(rasArr, inds, bands):
+    try:
+        return {b[0]: rasArr[inds[0], inds[1], b[2]].item() for b in bands}
+    except:
+        return {b[0]: -999 for b in bands}
+
 def getRasterValues(geoJSON, rasArr, UIDs, bounds, outputGeom, bands, color, outGeoJSON=False):
     rasInd = tools.rasterIndexer(rasArr.shape, bounds)
 
@@ -81,14 +87,14 @@ def getRasterValues(geoJSON, rasArr, UIDs, bounds, outputGeom, bands, color, out
     if outputGeom:
         if outGeoJSON:
             geoJSON = outGeoJSON
-        return list(
+        yield list(
             addGeoJSONprop(feat, bands, rasArr[indices[i][0],indices[i][1]], color) for i, feat in enumerate(geoJSON)
             )
     else: 
-        return list(
+        yield list(
             {
                 'qt': UIDs[i],
-                'attributes': {b[0]: rasArr[inds[0], inds[1], b[2]].item() for b in bands}
+                'attributes': getData(rasArr, inds, bands)
             } for i, inds in enumerate(indices)
             )
 
@@ -182,7 +188,7 @@ def fillFacets(geoJSONpath, rasterPath, noProject, output, bands, zooming, batch
         with open(output, 'w') as oFile:
             oFile.write(json.dumps({
                 "type": "FeatureCollection",
-                "features": sampleVals
+                "features": list(sampleVals)
                 }))
     else:
         for feat in sampleVals:

--- a/makesurface/scripts/triangulate_raster.py
+++ b/makesurface/scripts/triangulate_raster.py
@@ -62,6 +62,27 @@ def getCorners(bounds, boolKey):
         corners[coordOrd[boolKey][1]]
     ]
 
+def createDBinit(tileMin, tileMax, zoom, parentGet, tableid):
+    for r in range(tileMin.y, tileMax.y + 1):
+        for c in range(tileMin.x, tileMax.x + 1):
+            quad = tools.quadtree(c, r, zoom)
+            boolKey = (r+c) % 2 == 0
+            n = parentGet.getParents('n', c, r, zoom)
+            s = parentGet.getParents('s', c, r, zoom)
+            nQT = ''.join(np.dstack((n, quad)).flatten()) + 'n'
+            sQT = ''.join(np.dstack((s, quad)).flatten()) + 's'
+
+            yield {
+                'id': tableid,
+                'qt': nQT
+            }
+
+            yield {
+                'id': tableid,
+                'qt': nQT
+            }
+
+
 def createFacets(tileMin, tileMax, zoom, parentGet):
     for r in range(tileMin.y, tileMax.y + 1):
         for c in range(tileMin.x, tileMax.x + 1):
@@ -94,7 +115,7 @@ def createFacets(tileMin, tileMax, zoom, parentGet):
                     }
                 }
 
-def triangulate(zoom, output, bounds=None, tile=None):
+def triangulate(zoom, output, bounds, tile, tableid):
     if bounds:
         bounds = np.array(bounds).astype(np.float64)
     elif tile:
@@ -115,7 +136,10 @@ def triangulate(zoom, output, bounds=None, tile=None):
 
     pGet = facetParent()
 
-    gJSON = createFacets(tileMin, tileMax, zoom, pGet)
+    if tableid:
+        gJSON = createDBinit(tileMin, tileMax, zoom, pGet, tableid)
+    else:
+        gJSON = createFacets(tileMin, tileMax, zoom, pGet)
 
     if output:
         with open(output, 'w') as oFile:

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open('README.rst', encoding='utf-8') as f:
 
 
 setup(name='makesurface',
-      version='0.2.9',
+      version='0.2.10',
       description="Create vector datasets from raster surfaces",
       long_description=long_description,
       classifiers=[],

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open('README.rst', encoding='utf-8') as f:
 
 
 setup(name='makesurface',
-      version='0.2.8',
+      version='0.2.9',
       description="Create vector datasets from raster surfaces",
       long_description=long_description,
       classifiers=[],


### PR DESCRIPTION
Adds:

- Option for a dynamodb setup; `makesurface fillfacets <∆z> --tile <x> <y> <z> --tableid <table id string>` returns a line-delim stream of: `{"id":"tri","qt":"s0s2n1n2n0s3s3s3s3s3s2n"}`
- try / except handling for bad raster indices